### PR TITLE
feat(message-composer): add 'clear' emitter to clear message-composer

### DIFF
--- a/src/components/ComposerSlate/composer.js
+++ b/src/components/ComposerSlate/composer.js
@@ -105,6 +105,7 @@ const Composer = ({emitter, active, markdown, mentions, send, disabled, draft, n
     emitter.on('INSERT_TEXT', insert);
 
     emitter.on('SEND', () => editor.current.sendMessage());
+    emitter.on('CLEAR', () => editor.current.clearMessage());
 
     return () => {
       emitter.off('toggleBold');
@@ -121,6 +122,7 @@ const Composer = ({emitter, active, markdown, mentions, send, disabled, draft, n
       emitter.off('INSERT_TEXT', insert);
 
       emitter.off('SEND');
+      emitter.off('CLEAR');
     };
   }, [emitter]);
 

--- a/src/components/ComposerSlate/send-message.js
+++ b/src/components/ComposerSlate/send-message.js
@@ -259,6 +259,13 @@ const serializePlugin = (value) => {
           editor.focus();
         });
       },
+      clearMessage(editor) {
+        editor.props.onChange({value});
+
+        setTimeout(() => {
+          editor.focus();
+        });
+      },
     },
   };
 };

--- a/src/index.stories.js
+++ b/src/index.stories.js
@@ -134,6 +134,11 @@ export const Example = () => {
     emitter.current.emit('SEND');
   };
 
+  const clear = (e) => {
+    e.preventDefault();
+    emitter.current.emit('CLEAR');
+  };
+
   const onSend = (val) => {
     setMessage(val);
 
@@ -191,6 +196,7 @@ export const Example = () => {
         <button onClick={toggleMarkdownDisabled}>{isMarkdownDisabled ? 'enable markdown' : 'disable markdown'}</button>
         <button onClick={toggleFailSend}>{failSend ? 'send message successfully' : 'make send message fail'}</button>
         <button onClick={send}>SEND</button>
+        <button onClick={clear}>CLEAR</button>
         <button onClick={changePlaceholder}>Change placeholder</button>
       </div>
     </div>


### PR DESCRIPTION
Add an emitter/listener to support the clear message functionality.
This is needed to support the clearing the message after the user sends the message using the `ConfirmModal`.
Earlier the message just used to disappear when the ConfirmModal showed up.