### PR TITLE
feat(key bindings): add quill helpers to key binding handler params

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You will need Node v11+ and Yarn installed.
 `yarn build` to build the composer.
 
 To link with the client, run `yarn link` in your message composer terminal, then run `yarn link @webex/message-composer` in the client terminal.
-You will need to build the composer after making changes for them to take effect.
+You will need to build the composer after making changes for them to take effect. To unlink, run `yarn unlink @webex/message-composer` in the client terminal, then `yarn` to rebuild the original package from deployed package.
 
 To test without linking to a client, run `yarn storybook`.
 

--- a/src/components/ComposerQuill/composer.js
+++ b/src/components/ComposerQuill/composer.js
@@ -141,14 +141,14 @@ class Composer extends React.Component {
   componentDidUpdate(prevProps) {
     const {draft, mentions, placeholder, keyBindings} = this.props;
 
-    const keyBindingDelta = getKeyBindingDelta(prevProps.keyBindings, keyBindings);
-
-    if (!isEmpty(keyBindingDelta)) {
-      addEmptyCheckToHandlerParams(keyBindings);
-      updateKeyBindings(this.quill, keyBindingDelta, keyBindings);
-    }
-
     try {
+      const keyBindingDelta = getKeyBindingDelta(prevProps.keyBindings, keyBindings);
+
+      if (!isEmpty(keyBindingDelta)) {
+        addEmptyCheckToHandlerParams(keyBindings);
+        updateKeyBindings(this.quill, keyBindingDelta, keyBindings);
+      }
+
       const prevDraft = prevProps.draft;
 
       // updates the text in the composer as we switch conversations
@@ -385,6 +385,10 @@ class Composer extends React.Component {
 
   handleFocus() {
     this.quill.focus();
+
+    const length = this.quill.getLength();
+
+    this.quill.setSelection(length - 1);
   }
 
   handleClear() {
@@ -427,7 +431,7 @@ Composer.propTypes = {
 
 Composer.defaultProps = {
   draft: undefined,
-  keyBindings: undefined,
+  keyBindings: {},
   markdown: undefined,
   mentions: undefined,
   notifyKeyDown: undefined,

--- a/src/components/ComposerQuill/composer.js
+++ b/src/components/ComposerQuill/composer.js
@@ -68,6 +68,7 @@ class Composer extends React.Component {
       emitter.on('FOCUS', this.handleFocus);
       emitter.on('CLEAR', this.handleClear);
 
+      // binds additional util fnc to keybinding handler callback
       const boundKeyBindings = addEmptyCheckToHandlerParams(keyBindings);
 
       const bindings = {
@@ -142,6 +143,7 @@ class Composer extends React.Component {
     const {draft, mentions, placeholder, keyBindings} = this.props;
 
     try {
+      // checks if keybindings need to be updated
       const keyBindingDelta = getKeyBindingDelta(prevProps.keyBindings, keyBindings);
 
       if (!isEmpty(keyBindingDelta)) {
@@ -386,8 +388,10 @@ class Composer extends React.Component {
   handleFocus() {
     this.quill.focus();
 
+    // empty quill editor getLength returns 1, so it is safe to use length-1 to point to cursor index 0
     const length = this.quill.getLength();
 
+    // position cursor at end of content, if any
     this.quill.setSelection(length - 1);
   }
 

--- a/src/components/ComposerQuill/utils.js
+++ b/src/components/ComposerQuill/utils.js
@@ -232,28 +232,36 @@ export function keepReplacement(content, node) {
   return content;
 }
 
+// quill's empty state is not really empty, needs custom matcher
+const emptyQuillContentsMatcher = '{"ops":[{"insert":"\\n"}]}';
+
 export function isQuillEmpty(quill) {
-  if (JSON.stringify(quill.getContents()) === '{"ops":[{"insert":"\\n"}]}') {
+  if (JSON.stringify(quill.getContents()) === emptyQuillContentsMatcher) {
     return true;
   }
 
   return false;
 }
 
+// takes keyBindings passed as props, returns decorated keybindings
 export function addEmptyCheckToHandlerParams(keyBindings) {
   const keyBindingKeys = Object.keys(keyBindings);
 
   return keyBindingKeys.reduce((decoratedKeyBindings, keyBindingKey) => {
     const keyBinding = keyBindings[keyBindingKey];
+    // store original handler fnc
     const keyBindingHandler = keyBinding.handler;
 
+    // monkey patch for handler function that passes reference to quill editor without losing this binding
     keyBinding.handler = function handler(range, context) {
+      // stores this binding for closing over in util function
       const that = this;
 
       function boundIsQuillEmpty() {
         return isQuillEmpty(that.quill);
       }
 
+      // calls handler with util passed through
       return keyBindingHandler(range, context, boundIsQuillEmpty);
     };
 
@@ -264,6 +272,7 @@ export function addEmptyCheckToHandlerParams(keyBindings) {
   }, {});
 }
 
+// compares key binding uniqueIds to find bindings that need replacing
 export function getKeyBindingDelta(prevKeyBindings, newKeyBindings) {
   const newKeyBindingsKeys = Object.keys(newKeyBindings);
 
@@ -273,6 +282,7 @@ export function getKeyBindingDelta(prevKeyBindings, newKeyBindings) {
     const oldId = prevKeyBindings[currentKey]?.uniqueId;
     const newId = newKeyBindings[currentKey]?.uniqueId;
 
+    // new ID exists and doesnt match old ID, flag for update
     if (typeof newId !== 'undefined' && oldId !== newId) {
       keysToUpdate[currentKey] = oldId;
     }
@@ -281,21 +291,25 @@ export function getKeyBindingDelta(prevKeyBindings, newKeyBindings) {
   return keysToUpdate;
 }
 
+// replaces quill instance's outdated key bindings with fresh data and callbacks
 export function updateKeyBindings(quill, bindingsToReplace, newKeyBindings) {
   const quillBindings = quill.keyboard.bindings;
 
+  // loop over keys and values of outdated bindings
   for (const [bindingName, idToReplace] of Object.entries(bindingsToReplace)) {
     const currentNewBinding = newKeyBindings[bindingName];
     const currentKeyCode = currentNewBinding.key;
+    // all bindings registered to quill instance
     const currentQuillBindings = quillBindings[currentKeyCode];
-    const quillBindingToReplace = currentQuillBindings.findIndex((currentBinding) => {
-      return typeof currentBinding.uniqueId !== 'undefined' && currentBinding.uniqueId === idToReplace;
-    });
+    // compares binding's id to id that needs to be replaced with fresh data
+    const quillBindingToReplace = currentQuillBindings.findIndex(
+      (currentBinding) => typeof currentBinding.uniqueId !== 'undefined' && currentBinding.uniqueId === idToReplace
+    );
 
+    // remove the old binding, if it exists
     if (quillBindingToReplace > -1) {
       currentQuillBindings.splice(quillBindingToReplace, 1);
     }
-
-    quill.keyboard.addBinding(newKeyBindings[bindingName]);
+    quill.keyboard.addBinding(currentNewBinding);
   }
 }


### PR DESCRIPTION
this PR adds ability to pass an additional quill helper function to the keyBinding module handler callbacks.

The motivation is to keep quill-specific logic in quill, and not out in the caller's codebase.

message-composer component receives key bindings as props from caller, patches the handler function to pass an additional helper function to the keybinding's handler callback, and registers these keyBinding objects with quill instance.

Passed-in keyBinding objects will be keyed using a semantic property name, such as "upArrow" to refer to key code 38. This 

If caller needs to rebind a particular key binding for any reason, keyBinding object may contain an optional `uniqueId` property, allowing a named binding to be replaced in place by another. NOTE: the keyBindings are keyed by unique object property as well, therefore any keyBinding that should 

Why is this necessary? Cantina's instance of quill component is not unmounted and re-mounted for every space change, but the keyBinding handler function may need to perform a different action when a space changes. Cantina, for instance, passes quill a new keyBinding object on every space change, complete with a new uniqueId. To avoid adding keyBindings to a particular key code on a persistent quill instance endlessly, these handlers must be added and removed on the fly as cantina user navigates spaces.

This functionality has no effect on key bindings that do not specify a unique ID on the keyBinding object.